### PR TITLE
Support for Flutter 3.19.0

### DIFF
--- a/.github/workflows/pr_web.yml
+++ b/.github/workflows/pr_web.yml
@@ -105,6 +105,6 @@ jobs:
     - name: Save WEB to artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: web
+        name: web-${{ matrix.renderer }}
         path: flutter_theoplayer_sdk/example/build/web/
         retention-days: 5

--- a/.github/workflows/pr_web.yml
+++ b/.github/workflows/pr_web.yml
@@ -1,8 +1,8 @@
 name: Build Web on PRs
 on:
   workflow_dispatch:
-  #pull_request:
-  #  types: [opened, reopened, synchronize]
+  pull_request:
+    types: [opened, reopened, synchronize]
 
 jobs:
   build_web:

--- a/.github/workflows/pr_web.yml
+++ b/.github/workflows/pr_web.yml
@@ -6,7 +6,13 @@ on:
 
 jobs:
   build_web:
+    
+    strategy:
+      matrix:
+        renderer: [html, canvaskit]
+
     runs-on: ubuntu-latest
+
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -82,7 +88,7 @@ jobs:
     - name: Run integration tests
       run: |
         flutter config --enable-web
-        flutter drive --driver=webdriver_integration_test/webdriver.dart --target=integration_test/plugin_integration_test.dart -d web-server --profile --driver-port=4444 -v --web-browser-flag="--disable-web-security --autoplay-policy=no-user-gesture-required" --chrome-binary ${{ steps.setup-chrome.outputs.chrome-path }}
+        flutter drive --driver=webdriver_integration_test/webdriver.dart --target=integration_test/plugin_integration_test.dart -d web-server --web-renderer ${{ matrix.renderer }} --profile --driver-port=4444 -v --web-browser-flag="--disable-web-security --autoplay-policy=no-user-gesture-required" --chrome-binary ${{ steps.setup-chrome.outputs.chrome-path }}
       working-directory: flutter_theoplayer_sdk/example
       env:
         TEST_LICENSE: ${{ secrets.TEST_LICENSE }}

--- a/.github/workflows/pr_web.yml
+++ b/.github/workflows/pr_web.yml
@@ -36,47 +36,39 @@ jobs:
     - name: Install Chrome Browser
       uses: browser-actions/setup-chrome@v1
       with:
-        chrome-version: '114.0.5735.90'
+        chrome-version: '121.0.6167.184'
       id: setup-chrome
 
     - name: Check Browser version
       run: |
         echo Installed chromium version: ${{ steps.setup-chrome.outputs.chrome-version }}
         ${{ steps.setup-chrome.outputs.chrome-path }} --version
-        export CHROME_EXECUTABLE=${{ steps.setup-chrome.outputs.chrome-path }}
-        echo CHROME_EXECUTABLE = $CHROME_EXECUTABLE
-        echo Relinking Chrome
-        sudo ln -sf $CHROME_EXECUTABLE /usr/bin/google-chrome
-    - name: Checkout webdriver repo (alternarive way)
-      uses: actions/checkout@v2
-      with:
-        repository: flutter/web_installers
-        path: webdrivers
 
     - name: Install Chromedriver
-      run: |
-        flutter pub get
-        dart lib/web_driver_installer.dart chromedriver --driver-version="114.0.5735.90" --always-install --install-only
-      working-directory: webdrivers/packages/web_drivers/
+      uses: nanasess/setup-chromedriver@v2
+      with:
+        chromedriver-version: '121.0.6167.184'
 
     - name: ⏳ Delay
       run: |
         echo "Waiting for Chromedriver to install..."
-        sleep 2
+        sleep 1
+
+    - name: Check Chromedriver Version
+      run: chromedriver -v
         
     # if we use '-d chrome' and '--no-headless' for 'flutter drive' later, we can enable this
     #
-    #- name: Configure non-headless display
-    #  run: |
-    #    export DISPLAY=:99.0
-    #    echo "DISPLAY=:99.0" >> $GITHUB_ENV
-    #    Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
-    #    sleep 3
+    - name: Configure non-headless display
+      run: |
+        export DISPLAY=:99.0
+        echo "DISPLAY=:99.0" >> $GITHUB_ENV
+        Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
+        sleep 3
 
     - name: Start Chromedriver
       run: |
-        chromedriver/chromedriver --port=4444 --verbose --log-path=chromedriver.log &
-      working-directory: webdrivers/packages/web_drivers/
+        chromedriver --port=4444 --verbose --log-path=chromedriver.log &
 
     - name: ⏳ Delay
       run: |
@@ -90,7 +82,7 @@ jobs:
     - name: Run integration tests
       run: |
         flutter config --enable-web
-        flutter drive --driver=webdriver_integration_test/webdriver.dart --target=integration_test/plugin_integration_test.dart -d web-server --profile --browser-name=chrome --driver-port=4444 -v --web-browser-flag="--disable-web-security --autoplay-policy=no-user-gesture-required"
+        flutter drive --driver=webdriver_integration_test/webdriver.dart --target=integration_test/plugin_integration_test.dart -d web-server --profile --driver-port=4444 -v --web-browser-flag="--disable-web-security --autoplay-policy=no-user-gesture-required" --chrome-binary ${{ steps.setup-chrome.outputs.chrome-path }}
       working-directory: flutter_theoplayer_sdk/example
       env:
         TEST_LICENSE: ${{ secrets.TEST_LICENSE }}
@@ -99,7 +91,6 @@ jobs:
       if: always()
       run: |
         cat chromedriver.log
-      working-directory: webdrivers/packages/web_drivers/
 
     - name: Build Web
       run: flutter build web

--- a/flutter_theoplayer_sdk/example/pubspec.lock
+++ b/flutter_theoplayer_sdk/example/pubspec.lock
@@ -61,10 +61,10 @@ packages:
     dependency: transitive
     description:
       name: file
-      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
+      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.4"
+    version: "7.0.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -111,6 +111,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.7"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.0"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   lints:
     dependency: transitive
     description:
@@ -123,42 +147,42 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   platform:
     dependency: transitive
     description:
       name: platform
-      sha256: ae68c7bfcd7383af3629daafb32fb4e8681c7154428da4febcff06200585f102
+      sha256: "12220bb4b65720483f8fa9450b4332347737cf8213dd2840d8b2c823e47243ec"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "3.1.4"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -171,10 +195,10 @@ packages:
     dependency: transitive
     description:
       name: process
-      sha256: "53fd8db9cec1d37b0574e12f07520d582019cb6c44abf5479a01505099a34a09"
+      sha256: "21e54fd2faf1b5bdd5102afd25012184a6793927648ea81eea80552ac9405b32"
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.4"
+    version: "5.0.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -287,26 +311,18 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: c538be99af830f478718b51630ec1b6bee5e74e52c8a802d328d9e71d35d2583
+      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
       url: "https://pub.dev"
     source: hosted
-    version: "11.10.0"
-  web:
-    dependency: transitive
-    description:
-      name: web
-      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.3.0"
+    version: "13.0.0"
   webdriver:
     dependency: transitive
     description:
       name: webdriver
-      sha256: "3c923e918918feeb90c4c9fdf1fe39220fa4c0e8e2c0fffaded174498ef86c49"
+      sha256: "003d7da9519e1e5f329422b36c4dcdf18d7d2978d1ba099ea4e45ba490ed845e"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.3"
 sdks:
-  dart: ">=3.2.6 <4.0.0"
-  flutter: ">=3.16.9"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.19.0"

--- a/flutter_theoplayer_sdk/example/pubspec.lock
+++ b/flutter_theoplayer_sdk/example/pubspec.lock
@@ -315,6 +315,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "13.0.0"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "1d9158c616048c38f712a6646e317a3426da10e884447626167240d45209cbad"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
   webdriver:
     dependency: transitive
     description:

--- a/flutter_theoplayer_sdk/example/pubspec.yaml
+++ b/flutter_theoplayer_sdk/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the THEOplayer plugin.
 publish_to: 'none'
 
 environment:
-  sdk: ^3.2.6
-  flutter: ">=3.16.9"
+  sdk: ^3.3.0
+  flutter: ">=3.19.0"
 
 dependencies:
   flutter:

--- a/flutter_theoplayer_sdk/pubspec.lock
+++ b/flutter_theoplayer_sdk/pubspec.lock
@@ -253,6 +253,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "13.0.0"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "1d9158c616048c38f712a6646e317a3426da10e884447626167240d45209cbad"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
 sdks:
   dart: ">=3.3.0 <4.0.0"
   flutter: ">=3.19.0"

--- a/flutter_theoplayer_sdk/pubspec.lock
+++ b/flutter_theoplayer_sdk/pubspec.lock
@@ -80,6 +80,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.7"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.0"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   lints:
     dependency: transitive
     description:
@@ -92,34 +116,34 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   plugin_platform_interface:
     dependency: "direct main"
     description:
@@ -221,14 +245,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  web:
+  vm_service:
     dependency: transitive
     description:
-      name: web
-      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
+      name: vm_service
+      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "13.0.0"
 sdks:
-  dart: ">=3.2.6 <4.0.0"
-  flutter: ">=3.16.9"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.19.0"

--- a/flutter_theoplayer_sdk/pubspec.yaml
+++ b/flutter_theoplayer_sdk/pubspec.yaml
@@ -5,8 +5,8 @@ homepage: https://theoplayer.com
 repository: https://github.com/THEOplayer/flutter-theoplayer-sdk
 
 environment:
-  sdk: ^3.2.6
-  flutter: ">=3.16.9"
+  sdk: ^3.3.0
+  flutter: ">=3.19.0"
 
 dependencies:
   flutter:

--- a/flutter_theoplayer_sdk_android/pubspec.lock
+++ b/flutter_theoplayer_sdk_android/pubspec.lock
@@ -67,6 +67,30 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.0"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   lints:
     dependency: transitive
     description:
@@ -79,34 +103,34 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -184,14 +208,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  web:
+  vm_service:
     dependency: transitive
     description:
-      name: web
-      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
+      name: vm_service
+      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "13.0.0"
 sdks:
-  dart: ">=3.2.6 <4.0.0"
-  flutter: ">=3.16.9"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.19.0"

--- a/flutter_theoplayer_sdk_android/pubspec.yaml
+++ b/flutter_theoplayer_sdk_android/pubspec.yaml
@@ -5,8 +5,8 @@ homepage: https://theoplayer.com
 repository: https://github.com/THEOplayer/flutter-theoplayer-sdk
 
 environment:
-  sdk: ^3.2.6
-  flutter: ">=3.16.9"
+  sdk: ^3.3.0
+  flutter: ">=3.19.0"
 
 dependencies:
   flutter:

--- a/flutter_theoplayer_sdk_ios/pubspec.lock
+++ b/flutter_theoplayer_sdk_ios/pubspec.lock
@@ -67,6 +67,30 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.0"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   lints:
     dependency: transitive
     description:
@@ -79,34 +103,34 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -184,14 +208,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  web:
+  vm_service:
     dependency: transitive
     description:
-      name: web
-      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
+      name: vm_service
+      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "13.0.0"
 sdks:
-  dart: ">=3.2.6 <4.0.0"
-  flutter: ">=3.16.9"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.19.0"

--- a/flutter_theoplayer_sdk_ios/pubspec.yaml
+++ b/flutter_theoplayer_sdk_ios/pubspec.yaml
@@ -5,8 +5,8 @@ homepage: https://theoplayer.com
 repository: https://github.com/THEOplayer/flutter-theoplayer-sdk
 
 environment:
-  sdk: ^3.2.6
-  flutter: ">=3.16.9"
+  sdk: ^3.3.0
+  flutter: ">=3.19.0"
 
 dependencies:
   flutter:

--- a/flutter_theoplayer_sdk_platform_interface/pubspec.lock
+++ b/flutter_theoplayer_sdk_platform_interface/pubspec.lock
@@ -275,6 +275,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.8.1"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.0"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   lints:
     dependency: transitive
     description:
@@ -295,26 +319,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   mime:
     dependency: transitive
     description:
@@ -335,10 +359,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   pigeon:
     dependency: "direct dev"
     description:
@@ -480,6 +504,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      url: "https://pub.dev"
+    source: hosted
+    version: "13.0.0"
   watcher:
     dependency: transitive
     description:
@@ -488,14 +520,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
-  web:
-    dependency: transitive
-    description:
-      name: web
-      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.3.0"
   web_socket_channel:
     dependency: transitive
     description:
@@ -513,5 +537,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.2.6 <4.0.0"
-  flutter: ">=3.16.9"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.19.0"

--- a/flutter_theoplayer_sdk_platform_interface/pubspec.yaml
+++ b/flutter_theoplayer_sdk_platform_interface/pubspec.yaml
@@ -5,8 +5,8 @@ homepage: https://theoplayer.com
 repository: https://github.com/THEOplayer/flutter-theoplayer-sdk
 
 environment:
-  sdk: ^3.2.6
-  flutter: ">=3.16.9"
+  sdk: ^3.3.0
+  flutter: ">=3.19.0"
 
 dependencies:
   flutter:

--- a/flutter_theoplayer_sdk_web/lib/theoplayer_api_web.dart
+++ b/flutter_theoplayer_sdk_web/lib/theoplayer_api_web.dart
@@ -1,8 +1,8 @@
 @JS()
 library THEOplayer.js;
 
-import 'dart:html';
 import 'package:js/js.dart';
+import 'package:web/web.dart';
 
 void initializeTHEOplayer() {
   //prepare for initialization
@@ -24,7 +24,7 @@ class THEOplayerEventListener {
 
 @JS("THEOplayer.ChromelessPlayer")
 class THEOplayerJS extends THEOplayerEventListener {
-  external THEOplayerJS(HtmlElement videoElement, THEOplayerConfigParams theoPlayerConfig);
+  external THEOplayerJS(HTMLElement videoElement, THEOplayerConfigParams theoPlayerConfig);
 
   external play();
   external pause();

--- a/flutter_theoplayer_sdk_web/lib/theoplayer_view_controller_web.dart
+++ b/flutter_theoplayer_sdk_web/lib/theoplayer_view_controller_web.dart
@@ -1,9 +1,7 @@
-import 'dart:html';
-
 import 'package:theoplayer_platform_interface/pigeon/apis.g.dart' as PlatformInterface;
 import 'package:theoplayer_platform_interface/theopalyer_config.dart';
-import 'package:theoplayer_platform_interface/theoplayer_event_dispatcher_interface.dart';
-import 'package:theoplayer_platform_interface/theoplayer_events.dart';
+import 'package:theoplayer_platform_interface/theoplayer_event_dispatcher_interface.dart' as PlatformInterfaceEventDispatcher;
+import 'package:theoplayer_platform_interface/theoplayer_events.dart' as PlatformInterfaceEvents;
 import 'package:theoplayer_platform_interface/theoplayer_view_controller_interface.dart';
 import 'package:theoplayer_platform_interface/track/mediatrack/theoplayer_audiotrack.dart';
 import 'package:theoplayer_platform_interface/track/mediatrack/theoplayer_videotrack.dart';
@@ -12,19 +10,19 @@ import 'package:theoplayer_web/player_event_forwarder_web.dart';
 import 'package:theoplayer_web/theoplayer_api_web.dart';
 import 'package:theoplayer_web/track/theoplayer_track_controller_web.dart';
 import 'package:theoplayer_web/transformers_web.dart';
+import 'package:web/web.dart';
 
 class THEOplayerViewControllerWeb extends THEOplayerViewController {
-  final String _divId;
+  final HTMLElement _playerWrapperDiv;
   late final String _channelSuffix;
   late final THEOplayerJS _theoPlayerJS;
   late final PlayerEventForwarderWeb _eventForwarder;
   late final THEOplayerTrackControllerWeb _tracksController;
 
-  THEOplayerViewControllerWeb(int id, this._divId, THEOplayerConfig theoPlayerConfig) : super(id) {
+  THEOplayerViewControllerWeb(int id, this._playerWrapperDiv, THEOplayerConfig theoPlayerConfig) : super(id) {
     _channelSuffix = id.toString();
-    var wrapperDiv = window.document.getElementById(_divId);
     _theoPlayerJS = THEOplayerJS(
-        wrapperDiv as HtmlElement,
+        _playerWrapperDiv,
         THEOplayerConfigParams(
           license: theoPlayerConfig.getLicense(),
           licenseUrl: theoPlayerConfig.getLicenseUrl(),
@@ -36,12 +34,12 @@ class THEOplayerViewControllerWeb extends THEOplayerViewController {
   String get channelSuffix => _channelSuffix;
 
   @override
-  void addEventListener(String eventType, EventListener<Event> listener) {
+  void addEventListener(String eventType, PlatformInterfaceEventDispatcher.EventListener<PlatformInterfaceEvents.Event> listener) {
     _eventForwarder.addEventListener(eventType, listener);
   }
 
   @override
-  void removeEventListener(String eventType, EventListener<Event> listener) {
+  void removeEventListener(String eventType, PlatformInterfaceEventDispatcher.EventListener<PlatformInterfaceEvents.Event> listener) {
     _eventForwarder.removeEventListener(eventType, listener);
   }
 

--- a/flutter_theoplayer_sdk_web/lib/theoplayer_web.dart
+++ b/flutter_theoplayer_sdk_web/lib/theoplayer_web.dart
@@ -25,7 +25,8 @@ class TheoplayerWeb extends TheoplayerPlatform {
       final div = document.createElement('div') as HTMLDivElement;
       div.id = (params as dynamic)["theoViewID"];
       div.className = 'theoplayer_wrapper';
-
+      div.style.width = '100%';
+      div.style.height = '100%';
       return div;
     });
   }

--- a/flutter_theoplayer_sdk_web/lib/theoplayer_web.dart
+++ b/flutter_theoplayer_sdk_web/lib/theoplayer_web.dart
@@ -2,7 +2,6 @@
 // of your plugin as a separate package, instead of inlining it in the same
 // package as the core of your plugin.
 // ignore: avoid_web_libraries_in_flutter
-import 'dart:html';
 import 'dart:ui_web' as ui;
 
 import 'package:flutter/widgets.dart';
@@ -10,18 +9,20 @@ import 'package:theoplayer_platform_interface/theopalyer_config.dart';
 import 'package:theoplayer_platform_interface/theoplayer_platform_interface.dart';
 import 'package:theoplayer_web/theoplayer_view_controller_web.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
+import 'package:web/web.dart';
 
 /// A web implementation of the TheoplayerPlatform of the Theoplayer plugin.
 class TheoplayerWeb extends TheoplayerPlatform {
   String viewType = 'com.theoplayer/theoplayer-view-native';
   String viewIDString = 'theoplayer_wrapper_';
-  int theoViewUniqueID = 0;
+  int theoViewUniqueID = -1;
 
   /// Constructs a TheoplayerWeb
   TheoplayerWeb() {
     // ignore: undefined_prefixed_name
+
     ui.platformViewRegistry.registerViewFactory(viewType, (int viewId, {Object? params}) {
-      final div = DivElement();
+      final div = document.createElement('div') as HTMLDivElement;
       div.id = (params as dynamic)["theoViewID"];
       div.className = 'theoplayer_wrapper';
 
@@ -49,7 +50,7 @@ class TheoplayerWeb extends TheoplayerPlatform {
       viewType: viewType,
       creationParams: creationParams,
       onPlatformViewCreated: (id) {
-        createdCallback(THEOplayerViewControllerWeb(id, generatedViewId, theoPlayerConfig));
+        createdCallback(THEOplayerViewControllerWeb(id, ui.platformViewRegistry.getViewById(id) as HTMLElement, theoPlayerConfig));
       },
     );
   }

--- a/flutter_theoplayer_sdk_web/pubspec.lock
+++ b/flutter_theoplayer_sdk_web/pubspec.lock
@@ -80,6 +80,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.7"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.0"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   lints:
     dependency: transitive
     description:
@@ -92,34 +116,34 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   plugin_platform_interface:
     dependency: "direct main"
     description:
@@ -197,14 +221,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  web:
+  vm_service:
     dependency: transitive
     description:
-      name: web
-      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
+      name: vm_service
+      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "13.0.0"
 sdks:
-  dart: ">=3.2.6 <4.0.0"
-  flutter: ">=3.16.9"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.19.0"

--- a/flutter_theoplayer_sdk_web/pubspec.lock
+++ b/flutter_theoplayer_sdk_web/pubspec.lock
@@ -229,6 +229,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "13.0.0"
+  web:
+    dependency: "direct main"
+    description:
+      name: web
+      sha256: "1d9158c616048c38f712a6646e317a3426da10e884447626167240d45209cbad"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
 sdks:
   dart: ">=3.3.0 <4.0.0"
   flutter: ">=3.19.0"

--- a/flutter_theoplayer_sdk_web/pubspec.yaml
+++ b/flutter_theoplayer_sdk_web/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   plugin_platform_interface: ^2.0.2
   js: ^0.6.7
   theoplayer_platform_interface: 1.0.0
+  web: ">=0.3.0 <0.6.0"
 
 dev_dependencies:
   flutter_test:

--- a/flutter_theoplayer_sdk_web/pubspec.yaml
+++ b/flutter_theoplayer_sdk_web/pubspec.yaml
@@ -5,8 +5,8 @@ homepage: https://theoplayer.com
 repository: https://github.com/THEOplayer/flutter-theoplayer-sdk
 
 environment:
-  sdk: ^3.2.6
-  flutter: ">=3.16.9"
+  sdk: ^3.3.0
+  flutter: ">=3.19.0"
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ homepage: https://theoplayer.com
 publish_to: 'none'
 
 environment:
-    sdk: ^3.2.6
-    flutter: ">=3.16.9"
+    sdk: ^3.3.0
+    flutter: ">=3.19.0"
 dev_dependencies:
     melos: ^3.1.1


### PR DESCRIPTION
Flutter 3.19.0 breaks our Web player creation. (it works with 3.16.9)

This PR updates the Flutter versions and applies changes that are compatible with 3.19.0