### PR TITLE
pass forgotten player creation parameters

### DIFF
--- a/flutter_theoplayer_sdk/CHANGELOG.md
+++ b/flutter_theoplayer_sdk/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased]
+
+* Fixed an issue where playback failed with license error when using Texture-based (SURFACE_TEXTURE, SURFACE_PRODUCER) rendering.
+
 ## 7.3.0
 
 * Updated THEOplayer to 7.3.0.

--- a/flutter_theoplayer_sdk_android/android/src/main/kotlin/com/theoplayer/flutter/TheoplayerPlugin.kt
+++ b/flutter_theoplayer_sdk_android/android/src/main/kotlin/com/theoplayer/flutter/TheoplayerPlugin.kt
@@ -47,7 +47,7 @@ class TheoplayerPlugin : FlutterPlugin, MethodChannel.MethodCallHandler {
                 val entry = if (useSurfaceTexture) this.flutterPluginBinding.textureRegistry.createSurfaceTexture() else this.flutterPluginBinding.textureRegistry.createSurfaceProducer()
                 Log.d("TheoplayerPlugin", "createPlayer - entry created: ${entry.id()}")
 
-                val theoplayer = this.theoPlayerViewFactory.createHeadless(flutterPluginBinding.applicationContext, entry, null);
+                val theoplayer = this.theoPlayerViewFactory.createHeadless(flutterPluginBinding.applicationContext, entry, call.arguments);
 
                 theoplayer.destroyListener = THEOplayerViewNative.DestroyListener {
                     Log.e("TheoplayerPlugin", "destroyListener - entry: ${entry.id()}")


### PR DESCRIPTION
this broke player creation with custom surfaces.

TODO: add changelog after develop is in sync with main