### PR TITLE
Add snapshots Maven repo for xagget builds

### DIFF
--- a/flutter_theoplayer_sdk/flutter_theoplayer_sdk_android/android/build.gradle
+++ b/flutter_theoplayer_sdk/flutter_theoplayer_sdk_android/android/build.gradle
@@ -19,6 +19,7 @@ rootProject.allprojects {
         google()
         mavenCentral()
         maven { url "https://maven.theoplayer.com/releases" }
+        maven { url "https://maven.theoplayer.com/snapshots" }
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds `maven.theoplayer.com/snapshots` repository to the Android build.gradle
- Xagget-tagged native SDK artifacts are published to the snapshots repo and need this to resolve at build time
- **No version loosening** — the exact pin is kept as-is; the xagget pipeline patches the version via sed in the pub cache

This is the minimal SDK-side change needed to support xagget Flutter builds. See THEOplayer/flutter-xagget-library#9 for the full pipeline.

## Test plan
- [x] Verified with [experiment run](https://github.com/THEOplayer/flutter-xagget-library/actions/runs/23779997002) — Android build resolves xagget-tagged artifact from snapshots repo successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)