### PR TITLE
docs: add SDK architecture documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,8 @@
 4. The project contains the `flutter_theoplayer_sdk/flutter_theoplayer_sdk/example` folder that can be used during development.
 5. Use `main.dart` to run the project
 
+For an overview of how the SDK is structured internally (packages, communication layers, rendering modes), check the [architecture documentation](doc/architecture.md).
+
 ### Pigeon
 The project uses pigeons for type-safe communication between Flutter and the native mobile platforms.
 
@@ -25,6 +27,36 @@ To add new communication interfaces:
 2. Run `dart run build_runner build --delete-conflicting-outputs` in `flutter_theoplayer_sdk/flutter_theoplayer_sdk_platform_interface` folder to generate the final (merged) pigeon file
    and subsequently to generate the platform-specific bindings based on the merged `pigeons_merged.dart` file.
 3. Implement the new APIs on the Flutter and native side.
+
+The code generation produces the following files (all of them are **committed to git**, so don't forget to regenerate and commit them after changing the pigeon definitions):
+
+| Output | Path |
+|--------|------|
+| Dart | `flutter_theoplayer_sdk_platform_interface/lib/pigeon/apis.g.dart` |
+| Kotlin | `flutter_theoplayer_sdk_android/android/src/main/kotlin/com/theoplayer/flutter/pigeon/APIs.g.kt` |
+| Swift | `flutter_theoplayer_sdk_ios/ios/Classes/pigeon/APIs.g.swift` |
+
+Every pigeon channel name is suffixed with `id_<playerId>` through `PigeonBinaryMessengerWrapper` (available in Dart, Kotlin and Swift) to support multiple player instances.
+
+### Adding a new cross-platform feature
+
+A typical feature touching all platforms (e.g. exposing a new player event) follows these steps:
+
+1. **Define** the new API/event in `flutter_theoplayer_sdk_platform_interface/pigeons/apis/*.dart` (and `pigeons/models/` if new data types are needed).
+2. **Generate code**: run `dart run build_runner build --delete-conflicting-outputs` in the `flutter_theoplayer_sdk_platform_interface` folder, and commit all regenerated files.
+3. **Dart plumbing** (platform interface): add the event class in `theoplayer_events.dart` and dispatch it in `theoplayer_flutter_api.dart`.
+4. **Dart facade** (`theoplayer` package): cache/expose the new state in `theoplayer_state.dart` / `theoplayer_internal.dart`.
+5. **Android**: handle it in `PlayerEventForwarder.kt` or the relevant bridge (add a `transformers/` conversion if needed).
+6. **iOS**: do the same in the Swift mirror files (`PlayerEventForwarder.swift`, etc.).
+7. **Web** (bypasses pigeon): add the JS interop binding in `theoplayer_api_event_web.dart` / `theoplayer_api_web.dart`, convert in `transformers_web.dart`, and forward in `player_event_forwarder_web.dart`.
+8. **Tests**: add integration tests in `example/integration_test/` (and make sure they are reachable from the web single entrypoint in `example/integration_test_single_entrypoint/`).
+
+For a bigger sub-API (like ABR or THEOlive), the pattern is:
+
+1. A dedicated pigeon bridge file in `pigeons/apis/`.
+2. A `XxxBridge.kt` + `XxxBridge.swift` pair (instantiated and disposed in `THEOplayerViewNative` on both platforms).
+3. A `XxxControllerMobile` (platform interface) + `XxxControllerWeb` (web package).
+4. Exposure via the `THEOplayerViewController` interface (`getXxx()`) and a holder/facade on `THEOplayer`, wired up in the `THEOplayer` constructor's `onCreated` callback.
 
 ## Pull-requests
 Before making a pull-request, please make sure:

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -1,0 +1,146 @@
+# THEOplayer Flutter SDK Architecture
+
+This document describes how the THEOplayer Flutter SDK is structured internally: how the packages relate to each other, how Dart talks to the native players, and how video is rendered on each platform.
+
+<img src="./theoplayer_flutter_sdk_arch.png" />
+
+## Overview
+
+The THEOplayer Flutter SDK is a **federated Flutter plugin** that wraps the native THEOplayer SDKs. It does **not** reimplement playback — every platform embeds the real native player:
+
+| Platform | Native SDK source |
+|----------|-------------------|
+| Android | `com.theoplayer.theoplayer-sdk-android:core` (Maven: `https://maven.theoplayer.com/releases`) |
+| iOS | `THEOplayerSDK-core` + `THEOplayer-Integration-THEOlive` (CocoaPods) |
+| Web | `THEOplayer.chromeless.js` (shipped manually in your app's `web/` folder) |
+
+The Flutter SDK version is **locked to the native player version** (e.g. Flutter SDK `10.12.3` uses native SDKs `10.12.3` on all platforms).
+
+## Package structure
+
+The repository is a [Melos](https://melos.invertase.dev) monorepo containing the packages of a standard [federated plugin](https://docs.flutter.dev/packages-and-plugins/developing-packages#federated-plugins) setup:
+
+| Path | Package | Description |
+|------|---------|-------------|
+| `flutter_theoplayer_sdk/flutter_theoplayer_sdk/` | `theoplayer` | App-facing package, public API |
+| `flutter_theoplayer_sdk/flutter_theoplayer_sdk_platform_interface/` | `theoplayer_platform_interface` | Contracts, Pigeon definitions, event system, shared mobile controller |
+| `flutter_theoplayer_sdk/flutter_theoplayer_sdk_android/` | `theoplayer_android` | Dart glue + Kotlin native plugin |
+| `flutter_theoplayer_sdk/flutter_theoplayer_sdk_ios/` | `theoplayer_ios` | Dart glue + Swift native plugin |
+| `flutter_theoplayer_sdk/flutter_theoplayer_sdk_web/` | `theoplayer_web` | Dart ⇄ JS interop (`dart:js_interop`, no Pigeon) |
+| `flutter_theoplayer_sdk/flutter_theoplayer_sdk/example/` | - | Demo app, hosts all integration tests |
+
+## Layer diagram
+
+```
+Your app
+   |
+THEOplayer (facade) ----> PlayerState (event-fed cache => synchronous getters)
+   |
+THEOplayerView (StatefulWidget)
+   |  initState -> TheoplayerPlatform.instance.initalize()
+   |  build     -> TheoplayerPlatform.instance.buildView()
+   |
+TheoplayerPlatform (federated, self-registration via registerWith())
+   |-- THEOplayerAndroid -> PlatformViewLink / Texture -> Kotlin THEOplayerViewNative
+   |-- THEOplayerIOS     -> UiKitView                  -> Swift THEOplayerViewNative
+   |-- TheoplayerWeb     -> HtmlElementView (div)      -> THEOplayerJS (js_interop)
+   |
+THEOplayerViewController (per-player; Mobile impl shared by Android+iOS, Web separate)
+   |
+   |-- Android + iOS: Pigeon channels (channel suffix "id_<playerId>" => multi-player support) <-> native bridges
+   |-- Web:           direct JS calls via dart:js_interop (no Pigeon)
+```
+
+### Key classes
+
+| Component | Location |
+|-----------|----------|
+| `THEOplayer` facade class | `flutter_theoplayer_sdk/lib/src/theoplayer_internal.dart` |
+| `PlayerState` (event-fed cache) | `flutter_theoplayer_sdk/lib/src/theoplayer_state.dart` |
+| `THEOplayerView` widget | `flutter_theoplayer_sdk/lib/src/theoplayer_view.dart` |
+| `TheoplayerPlatform` | `..._platform_interface/lib/theoplayer_platform_interface.dart` |
+| `THEOplayerViewController` contract | `..._platform_interface/lib/theoplayer_view_controller_interface.dart` |
+| Shared mobile controller | `..._platform_interface/lib/theoplayer_view_controller_mobile.dart` |
+| Pigeon definitions (source of truth) | `..._platform_interface/pigeons/` |
+| Android native entry | `..._android/android/src/main/kotlin/com/theoplayer/flutter/TheoplayerPlugin.kt` |
+| Android player wrapper | `..._android/.../THEOplayerViewNative.kt` |
+| iOS native entry | `..._ios/ios/Classes/TheoplayerPlugin.swift` |
+| Web JS interop bindings | `..._web/lib/theoplayer_api_web.dart` |
+
+## Dart ⇄ native communication
+
+The mobile platforms communicate through [Pigeon](https://pub.dev/packages/pigeon)-generated, type-safe channels:
+
+- `THEOplayerNativeAPI` (`@HostApi`): Dart → native calls (play, pause, setSource, ...).
+- `THEOplayerFlutterAPI` (`@FlutterApi`): native → Dart events.
+- Dedicated bridge APIs for text/audio/video tracks, THEOlive, ABR and debug flags.
+
+Every channel name is suffixed with `id_<playerId>` through `PigeonBinaryMessengerWrapper` (available in Dart, Kotlin and Swift), which is what allows **multiple player instances** to coexist.
+
+The **Web** implementation bypasses Pigeon entirely: `theoplayer_api_web.dart` binds to the THEOplayer Web SDK via `dart:js_interop`, and `transformers_web.dart` converts JS objects into the same model classes, so the upper layers stay platform-agnostic.
+
+See [CONTRIBUTING.md](../CONTRIBUTING.md) for the Pigeon code generation workflow and a step-by-step guide for adding new cross-platform features.
+
+### Event and state flow
+
+```
+native player event
+  -> PlayerEventForwarder (.kt / .swift) or player_event_forwarder_web.dart
+  -> THEOplayerFlutterAPI (pigeon channel, suffixed) / JS event listener
+  -> THEOplayerFlutterAPIImpl
+  -> EventManager
+  -> PlayerState (cache update) + user addEventListener callbacks
+```
+
+`PlayerState` subscribes to player events and caches values like `currentTime`, `duration` and `readyState`. **This is why getters on `THEOplayer` are synchronous** even though the underlying channel calls are asynchronous.
+
+### Native bridge pattern
+
+Each API domain gets its own bridge, instantiated per player in `THEOplayerViewNative` (Kotlin and Swift mirror each other almost 1:1):
+
+- `PlayerEventForwarder` — core player events
+- `TextTrackBridge`, `AudioTrackBridge`, `VideoTrackBridge` — track lists, track events, selection
+- `THEOliveBridge` — THEOlive-specific events/API
+- `AbrBridge` — ABR configuration
+- `DebugFlagsBridge` — native debug logging control
+- `transformers/` — pigeon ⇄ native model conversion
+
+## Rendering
+
+### Android: view composition modes
+
+Selected via `AndroidConfig.viewComposition` (`AndroidViewComposition` enum):
+
+| Mode | Mechanism | Type | Notes |
+|------|-----------|------|-------|
+| `HYBRID_COMPOSITION` | `initExpensiveAndroidView` | PlatformView | Legacy default (`AndroidConfig()`) |
+| `TEXTURE_LAYER` | `initAndroidView` | PlatformView | Virtual-display style |
+| `SURFACE_TEXTURE` | Flutter `Texture` + `TextureRegistry.createSurfaceTexture()` | Texture | Default for `AndroidConfig.create()` |
+| `SURFACE_PRODUCER` | Flutter `Texture` + `TextureRegistry.createSurfaceProducer()` | Texture | Impeller-compatible (Flutter ≥ 3.22) |
+
+**Texture mode flow** (`SURFACE_TEXTURE` / `SURFACE_PRODUCER`):
+
+1. `THEOplayerView.initState` → `TheoplayerPlatform.initalize()` → `PlatformPlayersService.createPlayer()` over the `com.theoplayer.global/players` method channel.
+2. `TheoplayerPlugin.onMethodCall("createPlayer")` creates a texture entry and a **headless** `THEOplayerViewNative` (no platform view); returns the texture id.
+3. Dart builds a `Texture(textureId)` widget (through `TextureManager`, which mimics the `PlatformViewLink` lifecycle).
+4. `THEOplayerViewControllerAndroid.configureSurface()` → native `player.setCustomSurface(surface, w, h)`.
+
+Caveat of texture modes: in-stream subtitles are **not** rendered — subtitle rendering must be implemented app-side using text track events.
+
+**PlatformView mode flow**: `initalize()` is a no-op; `buildView()` creates a `PlatformViewLink`/`AndroidViewSurface`; the player is constructed by `THEOplayerViewNativeFactory` when the platform view is created.
+
+### iOS
+
+Single path: `UiKitView` with view type `com.theoplayer/theoplayer-view-native`; `THEOplayerNativeViewFactory` is registered in `TheoplayerPlugin.swift`.
+
+### Web
+
+- `TheoplayerWeb` registers a view factory producing a wrapper `<div>` with a generated unique id; `THEOplayerViewControllerWeb` constructs `THEOplayerJS` on it directly.
+- Your app must ship `THEOplayer.chromeless.js` (plus the `theoplayer.d/e/p.js` worker files) in `web/`; `WebConfig.libraryLocation` must point to the worker location (required for HLS playback).
+- The implementation is WASM-compatible (`dart:js_interop` + `package:web`), see [wasm_support.md](./wasm_support.md).
+
+## Fullscreen & Picture-in-Picture
+
+- **Fullscreen** is handled on the Flutter side: setting `presentationMode = FULLSCREEN` pushes a fullscreen route (`FullscreenStatefulWidget`, customizable via the `fullscreenBuilder` constructor parameter) that reparents the same player view. Orientation and system UI follow `FullscreenConfig`.
+- **PiP**: on Web via `presentationMode = PIP` (browser API); on Android/iOS via `allowAutomaticPictureInPicture`, where native signals (`onUserLeaveHint` / AVKit callbacks) reach Flutter through the `PlatformActivityService` channel.
+- Detailed flow diagrams are documented inline in `theoplayer_internal.dart`, and user-facing documentation lives in [picture-in-picture.md](./picture-in-picture.md).

--- a/flutter_theoplayer_sdk/flutter_theoplayer_sdk/README.md
+++ b/flutter_theoplayer_sdk/flutter_theoplayer_sdk/README.md
@@ -136,7 +136,6 @@ and discussed in the next section. Finally, an overview of features, limitations
     - [Getting started on Web](https://github.com/THEOplayer/flutter-theoplayer-sdk/blob/main/doc/creating-minimal-app.md#getting-started-on-web)
 - [The THEOplayer component](https://github.com/THEOplayer/flutter-theoplayer-sdk/blob/main/doc/theoplayer-component.md)
 - Knowledge Base
-  - [SDK architecture](https://github.com/THEOplayer/flutter-theoplayer-sdk/blob/main/doc/architecture.md)
   - [Using custom DRM connectors](https://github.com/THEOplayer/flutter-theoplayer-sdk/blob/main/doc/custom_drm.md)
   - [Limitations and known issues](https://github.com/THEOplayer/flutter-theoplayer-sdk/blob/main/doc/limitations.md)
   - [Picture-in-picture](https://github.com/THEOplayer/flutter-theoplayer-sdk/blob/main/doc/picture-in-picture.md)

--- a/flutter_theoplayer_sdk/flutter_theoplayer_sdk/README.md
+++ b/flutter_theoplayer_sdk/flutter_theoplayer_sdk/README.md
@@ -136,6 +136,7 @@ and discussed in the next section. Finally, an overview of features, limitations
     - [Getting started on Web](https://github.com/THEOplayer/flutter-theoplayer-sdk/blob/main/doc/creating-minimal-app.md#getting-started-on-web)
 - [The THEOplayer component](https://github.com/THEOplayer/flutter-theoplayer-sdk/blob/main/doc/theoplayer-component.md)
 - Knowledge Base
+  - [SDK architecture](https://github.com/THEOplayer/flutter-theoplayer-sdk/blob/main/doc/architecture.md)
   - [Using custom DRM connectors](https://github.com/THEOplayer/flutter-theoplayer-sdk/blob/main/doc/custom_drm.md)
   - [Limitations and known issues](https://github.com/THEOplayer/flutter-theoplayer-sdk/blob/main/doc/limitations.md)
   - [Picture-in-picture](https://github.com/THEOplayer/flutter-theoplayer-sdk/blob/main/doc/picture-in-picture.md)


### PR DESCRIPTION
- doc/architecture.md: packages, layer diagram, pigeon communication, event/state flow, native bridge pattern, rendering modes, fullscreen/PiP
- CONTRIBUTING.md: pigeon codegen outputs, channel suffixing, step-by-step guide for adding cross-platform features and sub-APIs
